### PR TITLE
Fix de clé unique non valide

### DIFF
--- a/users/authentication.py
+++ b/users/authentication.py
@@ -70,6 +70,7 @@ class ViacesiAuthBackend:
             currentUser = User.objects.create_user(
                 user_info_json["mail"],
                 password=None,
+                username=user_info_json["mail"],
                 first_name=user_info_json["givenName"],
                 last_name=user_info_json["surname"].capitalize(),
                 viacesi_id=user_info_json["id"])


### PR DESCRIPTION
La clé unique `username` n'est pas utilisée mais est tout de même requise. En attendant une meilleur solution, j'ai enregistré l'email dans le username.